### PR TITLE
fix: Do not fail master on snapshot builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,9 @@ before_install:
 - git checkout -qf $TRAVIS_BRANCH
 install:
 - echo "skip default gradlew assemble"
-script: "./gradlew build cobertura -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN}
-  -Dorg.ajoberstar.grgit.auth.password"
-deploy:
-  provider: script
-  script: "./gradlew release
-    -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password
-    -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET} -Pgradle.publish.key=${GRADLE_PUBLISH_KEY}"
-  skip_cleanup: true
-  on:
-    branch: master
+script: "./gradlew build cobertura release
+  -Dorg.ajoberstar.grgit.auth.username=${GH_TOKEN} -Dorg.ajoberstar.grgit.auth.password
+  -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET} -Pgradle.publish.key=${GRADLE_PUBLISH_KEY}"
 env:
   global:
   - TERM=dumb

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ publishing {
     }
 }
 
+
 task wrapper(type: Wrapper) {
     gradleVersion = "3.5.1"
 }
@@ -208,23 +209,5 @@ semanticRelease {
     }
 }
 
-publish.dependsOn bintrayUpload
-publish.dependsOn publishPlugins
-
-prepare.doFirst  {
-  //We get grgit for free because we are using semantic-release
-  if(grgit.branch.getCurrent().name == "master" && version.toString().endsWith('-SNAPSHOT') && project.gradle.startParameter.taskNames.find { it == 'release' }) {
-    println """We are on the master branch, but the version is ending in -SNAPSHOT. The version only gets -SNAPSHOT dropped if:
-      * We are on the master branch
-      * The repo is clean
-      * There is a commit prefixed with 'fix:' or 'feat:' since the last release
-
-      If none of those things happened on the master branch then we will still land in the snapshot version strategy and have a version number with -SNAPSHOT.
-
-      See here for more details:
-
-      https://github.com/tschulte/gradle-semantic-release-plugin
-      """
-      throw new GradleException('Releasing -SNAPSHOT version on master branch')
-  }
-}
+if (!version.toString().endsWith('-SNAPSHOT'))
+    publish.dependsOn bintray, publishPlugins

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,9 @@ semanticRelease {
         releaseAsset sourcesJar, name: "sources.jar", label: 'sources jar', contentType: 'application/zip'
         releaseAsset javadocJar, name: "javadoc.jar", label: 'javadoc jar', contentType: 'application/zip'
     }
+    releaseBranches {
+        include 'master'
+    }
 }
 
 if (!version.toString().endsWith('-SNAPSHOT'))


### PR DESCRIPTION
Really intended to get snapshots working, but not sure I have the time to make sure we have our group id reserved on oss.jfrog.org. Using this to validate #3 is fixed (even though this could just be a snapshot build).