### PR TITLE
Add 'rc' as a default blocked versioning scheme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ To configure the plugin, add a block like the following to your ``build.gradle``
     betablocker {
       enabled true
       whitelist = []
-      rejectedVersions = ["alpha", "beta", "m", "snap", "latest"]
+      rejectedVersions = ["alpha", "beta", "m", "snap", "latest", "rc"]
     }
 
 These properties are described in the following table:
@@ -61,7 +61,8 @@ Property               Type           Default                   Description
                                                                 of an artifact will prevent the plugin from rejecting
                                                                 any versions
 ``rejectedVersions``   List<String>   ``["alpha", "beta", "m",  A list of strings which if present in the version of an
-                                      "snap", "latest"]``       artifact will cause it to be rejected (case insensitive)
+                                      "snap", "latest",         artifact will cause it to be rejected (case insensitive).
+                                      "rc"]``
 =====================  =============  ========================  ========================================================
 
 License

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 artifact_name=betablocker-plugin
 artifact_group=com.adtran
-artifact_version=1.0
+artifact_version=1.1
 build_number=dev
 
 repo_url=

--- a/src/main/groovy/com/adtran/BetablockerPluginExtension.groovy
+++ b/src/main/groovy/com/adtran/BetablockerPluginExtension.groovy
@@ -18,5 +18,5 @@ package com.adtran
 class BetablockerPluginExtension {
     def enabled = true // boolean or callable
     List<String> whitelist = []
-    List<String> rejectedVersions = ["alpha", "beta", "m", "snap", "latest"]
+    List<String> rejectedVersions = ["alpha", "beta", "m", "snap", "latest", "rc"]
 }


### PR DESCRIPTION
This change adds 'rc' (which is a common non-release versioning scheme) to the list of default rejections.